### PR TITLE
static struct to avoid collision in global varibles.

### DIFF
--- a/src/o_console.c
+++ b/src/o_console.c
@@ -30,7 +30,7 @@ struct ITEN {
     ITEN  *next;
 };
 
-SDL_Rect r;
+static SDL_Rect r;
 
 static void thanks (OBJECT *o);
 void app_ConsoleDeteteIten (DATA_CONSOLE *data, ITEN *iten);

--- a/src/o_edit.c
+++ b/src/o_edit.c
@@ -14,7 +14,7 @@ typedef struct {
     int     d2;     // Position of cursor
 }DATA_EDIT;
 
-SDL_Rect r;
+static SDL_Rect r;
 
 int proc_edit (OBJECT *o, int msg, int value) {
     DATA_EDIT *data = app_GetData(o);


### PR DESCRIPTION
without it command :
gcc dream.c -o dream libapp.a -lSDL -Wall -O2

get error :
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/10.2.0/../../../../i686-w64-mi
ngw32/bin/ld.exe: libapp.a(o_console.o):o_console.c:(.bss+0x0): multiple definit
ion of `r'; libapp.a(o_edit.o):o_edit.c:(.bss+0x0): first defined here
collect2.exe: error: ld returned 1 exit status